### PR TITLE
feat: Add Spring Cloud Gateway microservice

### DIFF
--- a/gateway-microservice/pom.xml
+++ b/gateway-microservice/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.3</version> <!-- Use a recent Spring Boot version -->
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>gateway-microservice</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>gateway-microservice</name>
+    <description>Spring Cloud Gateway Microservice</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version> <!-- Use a recent Spring Cloud version -->
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gateway-microservice/src/main/java/com/example/gateway/GatewayApplication.java
+++ b/gateway-microservice/src/main/java/com/example/gateway/GatewayApplication.java
@@ -1,0 +1,13 @@
+package com.example.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
+
+}

--- a/gateway-microservice/src/main/resources/application.properties
+++ b/gateway-microservice/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+server.port=8080
+
+# Basic route to healthCare-back (assuming it will run on port 8081)
+spring.cloud.gateway.routes[0].id=healthcare_backend_route
+spring.cloud.gateway.routes[0].uri=http://localhost:8081
+spring.cloud.gateway.routes[0].predicates=Path=/healthCare-back/**
+
+# Optional: Add a simple "hello world" route for testing the gateway itself
+spring.cloud.gateway.routes[1].id=test_route
+spring.cloud.gateway.routes[1].uri=http://httpbin.org:80/get # httpbin.org is useful for testing
+spring.cloud.gateway.routes[1].predicates=Path=/test/**
+spring.cloud.gateway.routes[1].filters=StripPrefix=1

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>healthCare-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>HealthCare Parent POM</name>
+    <description>Parent POM for the HealthCare microservices application</description>
+
+    <modules>
+        <module>healthCare-back</module>
+        <module>gateway-microservice</module>
+    </modules>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Optional: Define spring-boot-starter-parent here if you want centralized version management
+         for Spring Boot across modules, though individual modules already have it.
+         If added, child modules might need to adjust their parent section or remove it if it matches.
+         For now, keeping it simple and letting modules manage their own Spring Boot parent.
+    -->
+
+</project>


### PR DESCRIPTION
This commit introduces a new Spring Cloud Gateway microservice named 'gateway-microservice'.

The gateway is configured to run on port 8080 and includes:
- A basic route for the 'healthCare-back' service (currently pointing to localhost:8081 and path /healthCare-back/**).
- A test route to httpbin.org for verifying gateway functionality.

A new root POM (`pom.xml`) has been added to the project to manage `healthCare-back` and `gateway-microservice` as Maven modules.

This is the first step towards a microservices architecture.